### PR TITLE
fix: remove non-existing extensions

### DIFF
--- a/sdks/dotnet/sulfone-helium/Domain/Core/CyanScript.cs
+++ b/sdks/dotnet/sulfone-helium/Domain/Core/CyanScript.cs
@@ -9,11 +9,6 @@ public interface ICyanTemplate
     Task<Cyan> Template(IInquirer inquirer, IDeterminism determinism);
 }
 
-public interface ICyanExtension
-{
-    Task<Cyan> Extension(IInquirer inquirer, IDeterminism determinism, CyanExtensionInput input);
-}
-
 public interface ICyanProcessor
 {
     Task<ProcessorOutput> Process(CyanProcessorInput input, CyanFileHelper fileHelper);

--- a/sdks/node/src/domain/core/cyan_script.ts
+++ b/sdks/node/src/domain/core/cyan_script.ts
@@ -10,10 +10,6 @@ interface ICyanTemplate {
   template(inquirer: IInquirer, determinism: IDeterminism): Promise<Cyan>;
 }
 
-interface ICyanExtension {
-  extension(inquirer: IInquirer, determinism: IDeterminism, input: CyanExtensionInput): Promise<Cyan>;
-}
-
 interface ICyanProcessor {
   process(input: CyanProcessorInput, fileHelper: CyanFileHelper): Promise<ProcessorOutput>;
 }
@@ -22,4 +18,4 @@ interface ICyanPlugin {
   plugin(input: CyanPluginInput): Promise<PluginOutput>;
 }
 
-export type { ICyanTemplate, ICyanExtension, ICyanProcessor, ICyanPlugin };
+export type { ICyanTemplate, ICyanProcessor, ICyanPlugin };

--- a/sdks/python/cyanprintsdk/domain/core/cyan_script.py
+++ b/sdks/python/cyanprintsdk/domain/core/cyan_script.py
@@ -2,7 +2,6 @@ from abc import abstractmethod, ABC
 
 from cyanprintsdk.domain.core.cyan import Cyan
 from cyanprintsdk.domain.core.cyan_script_model import (
-    CyanExtensionInput,
     CyanProcessorInput,
     CyanPluginInput,
 )
@@ -16,14 +15,6 @@ from cyanprintsdk.domain.processor.output import ProcessorOutput
 class ICyanTemplate(ABC):
     @abstractmethod
     async def template(self, inquirer: IInquirer, determinism: IDeterminism) -> Cyan:
-        pass
-
-
-class ICyanExtension(ABC):
-    @abstractmethod
-    async def extension(
-        self, inquirer: IInquirer, determinism: IDeterminism, i: CyanExtensionInput
-    ) -> Cyan:
         pass
 
 


### PR DESCRIPTION
- removed ICyanExtension interface from dotnet, node, and python SDKs
- updated export statements in node SDK to exclude ICyanExtension
- removed extension method from ICyanExtension in python SDK

the ICyanExtension interface was not implemented and is no longer needed, simplifying the codebase and improving maintainability.