### PR TITLE
docs: add Resolver SDK documentation [CU-86ewrbr69]

### DIFF
--- a/docs/developer/02-architecture.md
+++ b/docs/developer/02-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Helium provides identical functionality across three programming languages (Node.js, Python, .NET), enabling template authors to work with their preferred language while maintaining API compatibility through a shared HTTP protocol. Each SDK implements three core APIs: Template (interactive prompting), Processor (file transformation), and Plugin (post-processing).
+Helium provides identical functionality across three programming languages (Node.js, Python, .NET), enabling template authors to work with their preferred language while maintaining API compatibility through a shared HTTP protocol. Each SDK implements four core APIs: Template (interactive prompting), Processor (file transformation), Plugin (post-processing), and Resolver (conflict resolution).
 
 ## System Context
 
@@ -13,10 +13,12 @@ flowchart LR
     A[Boron Coordinator] --> B[Helium Template]
     A --> C[Helium Processor]
     A --> D[Helium Plugin]
+    A --> E[Helium Resolver]
 
-    B --> E[Cyan Config]
-    C --> F[Processed Files]
-    D --> G[Final Output]
+    B --> F[Cyan Config]
+    C --> G[Processed Files]
+    D --> H[Final Output]
+    E --> I[Merged Files]
 ```
 
 | Component         | Role                                                   |
@@ -25,9 +27,11 @@ flowchart LR
 | Helium Template   | Interactive prompting for Cyan config generation       |
 | Helium Processor  | File transformation based on template output           |
 | Helium Plugin     | Post-processing and file modifications                 |
+| Helium Resolver   | Conflict resolution for multi-layer files              |
 | Cyan Config       | Structured output defining processors and plugins      |
 | Processed Files   | Transformed files from processor execution             |
 | Final Output      | Complete output after all plugins execute              |
+| Merged Files      | Files merged from multiple template layers             |
 
 ### Component Interaction
 
@@ -84,6 +88,7 @@ sequenceDiagram
 | Template Service  | Manages checkpoint-based questioning flow | `sdks/node/src/domain/template/service.ts`<br>`sdks/python/cyanprintsdk/domain/template/service.py`<br>`sdks/dotnet/sulfone-helium/Domain/Template/Service.cs`                              |
 | Processor Service | Manages file transformation               | `sdks/node/src/domain/processor/service.ts`<br>`sdks/python/cyanprintsdk/domain/processor/service.py`<br>`sdks/dotnet/sulfone-helium/Domain/Processor/Service.cs`                           |
 | Plugin Service    | Manages post-processing hooks             | `sdks/node/src/domain/plugin/service.ts`<br>`sdks/python/cyanprintsdk/domain/plugin/service.py`<br>`sdks/dotnet/sulfone-helium/Domain/Plugin/Service.cs`                                    |
+| Resolver Service  | Manages conflict resolution for files     | `sdks/node/src/domain/resolver/service.ts`<br>`sdks/python/cyanprintsdk/domain/resolver/service.py`<br>`sdks/dotnet/sulfone-helium/Domain/Resolver/Service.cs`                              |
 | StatelessInquirer | Caches answers for checkpoint flow        | `sdks/node/src/domain/service/stateless_inquirer.ts`<br>`sdks/python/cyanprintsdk/domain/service/stateless_inquirer.py`<br>`sdks/dotnet/sulfone-helium/Domain/Service/StatelessInquirer.cs` |
 | CyanFileHelper    | Virtual file system abstraction           | `sdks/node/src/domain/core/fs/cyan_fs_helper.ts`<br>`sdks/python/cyanprintsdk/domain/core/fs/cyan_fs_helper.py`<br>`sdks/dotnet/sulfone-helium/Domain/Core/FileSystem/CyanFileHelper.cs`    |
 

--- a/docs/developer/features/00-README.md
+++ b/docs/developer/features/00-README.md
@@ -1,6 +1,6 @@
 # Features Overview
 
-This section covers the three core APIs exposed by the Helium SDKs: Template (interactive prompting), Processor (file transformation), and Plugin (post-processing hooks).
+This section covers the four core APIs exposed by the Helium SDKs: Template (interactive prompting), Processor (file transformation), Plugin (post-processing hooks), and Resolver (conflict resolution).
 
 ## Map
 
@@ -11,27 +11,30 @@ flowchart TD
     A[Template API] --> B[Cyan Config]
     B --> C[Processor API]
     B --> D[Plugin API]
-    A --> E[IInquirer]
-    A --> F[IDeterminism]
-    C --> G[CyanFileHelper]
+    B --> E[Resolver API]
+    A --> F[IInquirer]
+    A --> G[IDeterminism]
+    C --> H[CyanFileHelper]
 ```
 
-| Item           | Role                                     |
-| -------------- | ---------------------------------------- |
-| Template API   | Interactive questioning → Cyan config    |
-| Processor API  | File transformation based on Cyan config |
-| Plugin API     | Post-processing hooks after processing   |
-| IInquirer      | 6 question types for prompting           |
-| IDeterminism   | Cached non-deterministic values          |
-| CyanFileHelper | Virtual file system for processors       |
+| Item           | Role                                      |
+| -------------- | ----------------------------------------- |
+| Template API   | Interactive questioning → Cyan config     |
+| Processor API  | File transformation based on Cyan config  |
+| Plugin API     | Post-processing hooks after processing    |
+| Resolver API   | Conflict resolution for multi-layer files |
+| IInquirer      | 6 question types for prompting            |
+| IDeterminism   | Cached non-deterministic values           |
+| CyanFileHelper | Virtual file system for processors        |
 
 ## All Features
 
-| Item                                   | What                                             | Why                                                     | Key Files                                   |
-| -------------------------------------- | ------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------- |
-| [Template API](./01-template-api.md)   | Interactive prompting for Cyan config generation | Enables user input collection without server-side state | `sdks/node/src/domain/template/service.ts`  |
-| [Processor API](./02-processor-api.md) | File transformation engines                      | Apply templating logic to generate files                | `sdks/node/src/domain/processor/service.ts` |
-| [Plugin API](./03-plugin-api.md)       | Post-processing utilities                        | Add/remove/transform files after processing             | `sdks/node/src/domain/plugin/service.ts`    |
+| Item                                   | What                                               | Why                                                             | Key Files                                   |
+| -------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------- |
+| [Template API](./01-template-api.md)   | Interactive prompting for Cyan config generation   | Enables user input collection without server-side state         | `sdks/node/src/domain/template/service.ts`  |
+| [Processor API](./02-processor-api.md) | File transformation engines                        | Apply templating logic to generate files                        | `sdks/node/src/domain/processor/service.ts` |
+| [Plugin API](./03-plugin-api.md)       | Post-processing utilities                          | Add/remove/transform files after processing                     | `sdks/node/src/domain/plugin/service.ts`    |
+| [Resolver API](./04-resolver-api.md)   | Conflict resolution for files from multiple layers | Merge files when multiple templates contribute to the same path | `sdks/node/src/domain/resolver/service.ts`  |
 
 ## Groups
 
@@ -40,3 +43,4 @@ flowchart TD
 - **[Template API](./01-template-api.md)** - Interactive prompting → Cyan config
 - **[Processor API](./02-processor-api.md)** - File transformation
 - **[Plugin API](./03-plugin-api.md)** - Post-processing hooks
+- **[Resolver API](./04-resolver-api.md)** - Conflict resolution

--- a/docs/developer/features/04-resolver-api.md
+++ b/docs/developer/features/04-resolver-api.md
@@ -1,0 +1,142 @@
+# Resolver API
+
+**What**: Conflict resolution interface that receives multiple versions of the same file from different template layers and returns merged content.
+
+**Why**: Enables resolvers to implement custom merge strategies (JSON merge, YAML merge, etc.) when files conflict across template layers.
+
+**Key Files**:
+
+- `sdks/node/src/domain/resolver/service.ts` → `ResolverService.resolve()`
+- `sdks/node/src/domain/core/cyan_script.ts` → `ICyanResolver` interface
+- `sdks/node/src/api/resolver/lambda.ts` → `LambdaResolver`
+- `sdks/node/src/api/resolver/mapper.ts` → `ResolverMapper`
+- `sdks/node/src/main.ts` → `StartResolver()`, `StartResolverWithLambda()`
+- `sdks/python/cyanprintsdk/domain/resolver/service.py` → `ResolverService.resolve()`
+- `sdks/python/cyanprintsdk/main.py` → `start_resolver()`, `start_resolver_with_fn()`
+- `sdks/dotnet/sulfone-helium/Domain/Resolver/Service.cs` → `Resolve()`
+- `sdks/dotnet/sulfone-helium/Server.cs` → `StartResolver()`
+
+## Overview
+
+The Resolver API enables stateless conflict resolution services on port 5553. Resolvers receive multiple versions of the same file from different template layers and return merged content. This is useful when multiple templates contribute to the same file (e.g., `package.json` from frontend and backend templates).
+
+Resolvers are **stateless** - they receive file content directly in the request and return merged content in the response. No file system access is required.
+
+## Flow
+
+### High-Level
+
+```mermaid
+flowchart LR
+    A[Coordinator] --> B[POST /api/resolve]
+    B --> C[ResolverService.resolve]
+    C --> D[ICyanResolver.resolve]
+    D --> E[Merge files by strategy]
+    E --> F[Return ResolverOutput]
+    F --> G[Map to response]
+```
+
+### Detailed
+
+```mermaid
+sequenceDiagram
+    participant C as Coordinator
+    participant RS as ResolverService
+    participant R as ICyanResolver
+    participant M as Merge Logic
+
+    C->>RS: 1. POST /api/resolve (config, files[])
+    RS->>RS: 2. Map request to domain
+    RS->>R: 3. resolve(input)
+    R->>M: 4. Apply merge strategy
+    M->>M: 5. Combine file contents
+    M-->>R: 6. Merged content
+    R-->>RS: 7. ResolverOutput(path, content)
+    RS->>RS: 8. Map to response
+    RS-->>C: 9. ResolverRes(path, content)
+```
+
+| #   | Step                  | What                                    | Why                          | Key File                                   |
+| --- | --------------------- | --------------------------------------- | ---------------------------- | ------------------------------------------ |
+| 1   | POST /api/resolve     | Coordinator sends resolution request    | Initiate conflict resolution | `sdks/node/src/main.ts`                    |
+| 2   | Map request to domain | Mapper converts API types to domain     | Clean separation of concerns | `sdks/node/src/api/resolver/mapper.ts`     |
+| 3   | resolve(input)        | Service calls resolver                  | Begin resolution             | `sdks/node/src/domain/resolver/service.ts` |
+| 4   | Apply merge strategy  | Resolver applies config-driven strategy | Configurable merge behavior  | Resolver implementation                    |
+| 5   | Combine file contents | Merge multiple file versions            | Resolve conflicts            | Resolver implementation                    |
+| 6   | Merged content        | Strategy returns combined content       | Output ready                 | Resolver implementation                    |
+| 7   | ResolverOutput        | Resolver returns output                 | Complete resolution          | `sdks/node/src/domain/resolver/output.ts`  |
+| 8   | Map to response       | Mapper converts domain to API types     | Return to coordinator        | `sdks/node/src/api/resolver/mapper.ts`     |
+| 9   | ResolverRes           | Service returns response                | Complete request             | `sdks/node/src/api/resolver/res.ts`        |
+
+## ICyanResolver Interface
+
+```typescript
+interface ICyanResolver {
+  resolve(input: ResolverInput): Promise<ResolverOutput>;
+}
+```
+
+**Key Files**:
+
+- Node: `sdks/node/src/domain/core/cyan_script.ts`
+- Python: `sdks/python/cyanprintsdk/domain/core/cyan_script.py`
+- .NET: `sdks/dotnet/sulfone-helium/Domain/Core/CyanScript.cs`
+
+## Types
+
+### ResolverInput
+
+| Field  | Type                      | Description                                            |
+| ------ | ------------------------- | ------------------------------------------------------ |
+| config | `Record<string, unknown>` | Resolver-specific configuration (e.g., merge strategy) |
+| files  | `ResolvedFile[]`          | Array of file versions from different layers           |
+
+### ResolvedFile
+
+| Field   | Type         | Description                           |
+| ------- | ------------ | ------------------------------------- |
+| path    | `string`     | File path (same for all versions)     |
+| content | `string`     | File content                          |
+| origin  | `FileOrigin` | Source template and layer information |
+
+### FileOrigin
+
+| Field    | Type     | Description                                            |
+| -------- | -------- | ------------------------------------------------------ |
+| template | `string` | Full template spec (e.g., "username/template:version") |
+| layer    | `number` | Layer number in the template stack                     |
+
+### ResolverOutput
+
+| Field   | Type     | Description         |
+| ------- | -------- | ------------------- |
+| path    | `string` | File path           |
+| content | `string` | Merged file content |
+
+## Entry Points
+
+| SDK    | Interface Method                | Lambda Method                                              |
+| ------ | ------------------------------- | ---------------------------------------------------------- |
+| Node   | `StartResolver(ICyanResolver)`  | `StartResolverWithLambda(LambdaResolverFn)`                |
+| Python | `start_resolver(ICyanResolver)` | `start_resolver_with_fn(LambdaResolverFn)`                 |
+| .NET   | `StartResolver(ICyanResolver)`  | `StartResolver(Func<ResolverInput, Task<ResolverOutput>>)` |
+
+**Key Files**:
+
+- Node: `sdks/node/src/main.ts`
+- Python: `sdks/python/cyanprintsdk/main.py`
+- .NET: `sdks/dotnet/sulfone-helium/Server.cs`
+
+## Edge Cases
+
+- **Single file**: If only one file version is provided, return it as-is
+- **Empty files array**: Return empty output (should not happen in practice)
+- **Large files**: Content is passed as strings; consider streaming for very large files
+- **Binary files**: Content is base64-encoded; resolver must handle decoding
+
+## Related
+
+- [Template API](./01-template-api.md) - Generates Cyan config
+- [Processor API](./02-processor-api.md) - File transformation
+- [Plugin API](./03-plugin-api.md) - Post-processing hooks
+- [Resolver HTTP API](../surfaces/api/04-resolver-api.md) - HTTP endpoint details

--- a/docs/developer/modules/03-api-layer.md
+++ b/docs/developer/modules/03-api-layer.md
@@ -1,6 +1,6 @@
 # API Layer Module
 
-**What**: HTTP endpoints and DTOs for Template, Processor, and Plugin services.
+**What**: HTTP endpoints and DTOs for Template, Processor, Plugin, and Resolver services.
 
 **Why**: Exposes domain services via HTTP protocol, enabling communication with Boron coordinator.
 
@@ -9,6 +9,7 @@
 - `sdks/node/src/api/template/` - Template API endpoints and DTOs
 - `sdks/node/src/api/processor/` - Processor API endpoints and DTOs
 - `sdks/node/src/api/plugin/` - Plugin API endpoints and DTOs
+- `sdks/node/src/api/resolver/` - Resolver API endpoints and DTOs
 - `sdks/node/src/api/core/` - Shared DTOs
 - `sdks/node/src/main.ts` - Server startup and endpoint registration
 - `sdks/python/cyanprintsdk/api/` - Python equivalents
@@ -19,7 +20,7 @@
 What this module is responsible for:
 
 - HTTP server startup (Express/aiohttp/ASP.NET Core)
-- Endpoint registration for Template, Processor, Plugin
+- Endpoint registration for Template, Processor, Plugin, Resolver
 - Request/response DTO mapping
 - Health check endpoints
 - Graceful shutdown handling
@@ -43,6 +44,11 @@ api/
 │   ├── mapper.ts           # Request/response mappers
 │   ├── req.ts              # PluginRequest DTOs
 │   └── res.ts              # PluginResponse DTOs
+├── resolver/
+│   ├── lambda.ts           # LambdaResolver adapter
+│   ├── mapper.ts           # Request/response mappers
+│   ├── req.ts              # ResolverRequest DTOs
+│   └── res.ts              # ResolverResponse DTOs
 └── core/
     ├── answer_req.ts       # Answer request DTOs
     ├── answer_res.ts       # Answer response DTOs
@@ -60,6 +66,7 @@ api/
 | `template/res.ts`     | Template response DTOs                |
 | `processor/mapper.ts` | Processor request/response mapping    |
 | `plugin/mapper.ts`    | Plugin request/response mapping       |
+| `resolver/mapper.ts`  | Resolver request/response mapping     |
 | `core/*`              | Shared DTOs and mappers               |
 
 ## Dependencies
@@ -105,13 +112,21 @@ flowchart LR
 
 **Key File**: `sdks/node/src/main.ts` → `StartPlugin()`
 
+### Resolver API (Port 5553)
+
+| Endpoint       | Method | Purpose                |
+| -------------- | ------ | ---------------------- |
+| `/api/resolve` | POST   | Resolve file conflicts |
+
+**Key File**: `sdks/node/src/main.ts` → `StartResolver()`
+
 ## Entry Points
 
-| SDK    | Template                                       | Processor                                        | Plugin                                     |
-| ------ | ---------------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
-| Node   | `StartTemplate()`, `StartTemplateWithLambda()` | `StartProcessor()`, `StartProcessorWithLambda()` | `StartPlugin()`, `StartPluginWithLambda()` |
-| Python | `start_template()`, `start_template_with_fn()` | `start_processor()`, `start_processor_with_fn()` | `start_plugin()`, `start_plugin_with_fn()` |
-| .NET   | `StartTemplate()`                              | `StartProcessor()`                               | `StartPlugin()`                            |
+| SDK    | Template                                       | Processor                                        | Plugin                                     | Resolver                                       |
+| ------ | ---------------------------------------------- | ------------------------------------------------ | ------------------------------------------ | ---------------------------------------------- |
+| Node   | `StartTemplate()`, `StartTemplateWithLambda()` | `StartProcessor()`, `StartProcessorWithLambda()` | `StartPlugin()`, `StartPluginWithLambda()` | `StartResolver()`, `StartResolverWithLambda()` |
+| Python | `start_template()`, `start_template_with_fn()` | `start_processor()`, `start_processor_with_fn()` | `start_plugin()`, `start_plugin_with_fn()` | `start_resolver()`, `start_resolver_with_fn()` |
+| .NET   | `StartTemplate()`                              | `StartProcessor()`                               | `StartPlugin()`                            | `StartResolver()`                              |
 
 **Key Files**:
 

--- a/docs/developer/surfaces/api/00-README.md
+++ b/docs/developer/surfaces/api/00-README.md
@@ -5,6 +5,7 @@
 - Template: `http://localhost:5550`
 - Processor: `http://localhost:5551`
 - Plugin: `http://localhost:5552`
+- Resolver: `http://localhost:5553`
 
 ## Map
 
@@ -13,17 +14,20 @@ flowchart TD
     A[HTTP API] --> B[Template API<br/>Port 5550]
     A --> C[Processor API<br/>Port 5551]
     A --> D[Plugin API<br/>Port 5552]
-    B --> E[POST /api/template/init]
-    B --> F[POST /api/template/validate]
-    C --> G[POST /api/process]
-    D --> H[POST /api/plug]
+    A --> E[Resolver API<br/>Port 5553]
+    B --> F[POST /api/template/init]
+    B --> G[POST /api/template/validate]
+    C --> H[POST /api/process]
+    D --> I[POST /api/plug]
+    E --> J[POST /api/resolve]
 ```
 
-| API           | Port | Purpose                                 |
-| ------------- | ---- | --------------------------------------- |
-| Template API  | 5550 | Interactive questioning for Cyan config |
-| Processor API | 5551 | File transformation                     |
-| Plugin API    | 5552 | Post-processing hooks                   |
+| API           | Port | Purpose                                   |
+| ------------- | ---- | ----------------------------------------- |
+| Template API  | 5550 | Interactive questioning for Cyan config   |
+| Processor API | 5551 | File transformation                       |
+| Plugin API    | 5552 | Post-processing hooks                     |
+| Resolver API  | 5553 | Conflict resolution for multi-layer files |
 
 ## All Endpoints
 
@@ -33,6 +37,7 @@ flowchart TD
 | [Template Validate](./01-template-api.md#post-apitemplatevalidate) | POST   | Validate user input           | `sdks/node/src/main.ts` |
 | [Process](./02-processor-api.md#post-apiprocess)                   | POST   | Process files                 | `sdks/node/src/main.ts` |
 | [Plug](./03-plugin-api.md#post-apiplug)                            | POST   | Apply plugin                  | `sdks/node/src/main.ts` |
+| [Resolve](./04-resolver-api.md#post-apiresolve)                    | POST   | Resolve file conflicts        | `sdks/node/src/main.ts` |
 
 ## Health Check
 
@@ -57,3 +62,7 @@ All services provide a health check endpoint:
 ### Group 3: Plugin Endpoint
 
 - **[Plugin API](./03-plugin-api.md)** - `/api/plug`
+
+### Group 4: Resolver Endpoint
+
+- **[Resolver API](./04-resolver-api.md)** - `/api/resolve`

--- a/docs/developer/surfaces/api/04-resolver-api.md
+++ b/docs/developer/surfaces/api/04-resolver-api.md
@@ -1,0 +1,98 @@
+# Resolver API
+
+**Base Path**: `http://localhost:5553`
+
+**Key Files**:
+
+- Node: `sdks/node/src/main.ts` → `StartResolver()`
+- Python: `sdks/python/cyanprintsdk/main.py` → `start_resolver()`
+- .NET: `sdks/dotnet/sulfone-helium/Server.cs` → `StartResolver()`
+
+## Endpoints
+
+### POST /api/resolve
+
+Resolve conflicts between multiple file versions from different template layers.
+
+**Parameters**:
+
+| Name | In   | Type          | Required | Description        |
+| ---- | ---- | ------------- | -------- | ------------------ |
+| body | body | `ResolverReq` | Yes      | Resolution request |
+
+**Request Body** (`ResolverReq`):
+
+| Field  | Type                | Required | Description                                      |
+| ------ | ------------------- | -------- | ------------------------------------------------ |
+| config | `object`            | Yes      | Resolver-specific configuration (merge strategy) |
+| files  | `ResolvedFileReq[]` | Yes      | Array of file versions to merge                  |
+
+**ResolvedFileReq**:
+
+| Field   | Type            | Required | Description                           |
+| ------- | --------------- | -------- | ------------------------------------- |
+| path    | `string`        | Yes      | File path (same for all versions)     |
+| content | `string`        | Yes      | File content                          |
+| origin  | `FileOriginReq` | Yes      | Source template and layer information |
+
+**FileOriginReq**:
+
+| Field    | Type     | Required | Description                                            |
+| -------- | -------- | -------- | ------------------------------------------------------ |
+| template | `string` | Yes      | Full template spec (e.g., "username/template:version") |
+| layer    | `number` | Yes      | Layer number in the template stack                     |
+
+**Response** `200 OK` (`ResolverRes`):
+
+| Field   | Type     | Description         |
+| ------- | -------- | ------------------- |
+| path    | `string` | File path           |
+| content | `string` | Merged file content |
+
+**Key Files**:
+
+- Node: `sdks/node/src/api/resolver/req.ts` → `ResolverReq`
+- Node: `sdks/node/src/api/resolver/res.ts` → `ResolverRes`
+- Node: `sdks/node/src/main.ts` → Endpoint handler
+
+## DTOs
+
+### ResolverReq
+
+```typescript
+interface ResolverReq {
+  config: Record<string, unknown>;
+  files: ResolvedFileReq[];
+}
+
+interface ResolvedFileReq {
+  path: string;
+  content: string;
+  origin: FileOriginReq;
+}
+
+interface FileOriginReq {
+  template: string;
+  layer: number;
+}
+```
+
+**Key File**: `sdks/node/src/api/resolver/req.ts`
+
+### ResolverRes
+
+```typescript
+interface ResolverRes {
+  path: string;
+  content: string;
+}
+```
+
+**Key File**: `sdks/node/src/api/resolver/res.ts`
+
+## Error Codes
+
+| Code | Meaning        | Resolution                |
+| ---- | -------------- | ------------------------- |
+| 400  | Bad request    | Check request body format |
+| 500  | Internal error | Check container logs      |


### PR DESCRIPTION
## Summary

- Add Resolver API feature documentation (`04-resolver-api.md`)
- Add Resolver HTTP API surface documentation
- Update architecture overview with Resolver component
- Update features README with Resolver API
- Update API layer module with Resolver endpoints and entry points
- Update HTTP API overview with Resolver endpoint

## Ticket

- [CU-86ewrbr69](https://app.clickup.com/t/86ewrbr69)

## Changes

### New Files

| File | Description |
|------|-------------|
| `docs/developer/features/04-resolver-api.md` | Resolver API feature documentation with flow diagrams, types, and entry points |
| `docs/developer/surfaces/api/04-resolver-api.md` | HTTP API documentation for `/api/resolve` endpoint |

### Updated Files

| File | Changes |
|------|---------|
| `docs/developer/02-architecture.md` | Added Resolver to overview, diagram, and key components |
| `docs/developer/features/00-README.md` | Added Resolver API to features list and diagram |
| `docs/developer/modules/03-api-layer.md` | Added Resolver to structure, endpoints, and entry points table |
| `docs/developer/surfaces/api/00-README.md` | Added Resolver API to HTTP API overview |

## Test Plan

- [x] Documentation follows existing patterns (Processor API, Plugin API)
- [x] Pre-commit hooks pass (treefmt, gitlint)
- [x] All cross-references link to correct files

By Claude Code 🤖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Resolver API as a fourth core API for merging conflicting file versions across template layers, with endpoint /api/resolve on port 5553.

* **Documentation**
  * Comprehensive Resolver API documentation added, including architecture integration, system workflows, endpoint specifications, request/response schemas, and SDK implementation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->